### PR TITLE
Firing arc label cleanup

### DIFF
--- a/packages/ui/src/components/Viewport/FiringArcs/FiringArc.vue
+++ b/packages/ui/src/components/Viewport/FiringArcs/FiringArc.vue
@@ -31,7 +31,7 @@
 			:style="{ opacity: settings.firingArcOpacity }"
 		>
 			<div class="FiringArc__label-row">
-				<span class="FiringArc__span">
+				<span>
 					{{ getUnitLabel(artillery.unitMap.value, unitIdFrom) }} ->
 					{{ getUnitLabel(artillery.unitMap.value, unitIdTo) }}
 				</span>
@@ -114,8 +114,8 @@
 		transform: translate(-50%, -50%);
 		transform-origin: 50% 50%;
 
-		padding: 0.5em;
-		gap: 0.5em;
+		padding: 0.25em;
+		gap: 0.1em;
 
 		display: grid;
 		grid-template-columns: repeat(2, max-content);
@@ -123,6 +123,11 @@
 
 		background: var(--color-primary-contrast);
 		border: 1px solid;
+    border-radius: 0.3em;
+
+    font-size:  calc((16px + 2vmin) / 2);
+
+    line-height: 100%;
 
 		pointer-events: none;
 		user-select: none;
@@ -130,14 +135,14 @@
 		.FiringArc__label-row {
 			grid-column: 1 / -1;
 
-			display: grid;
-			grid-template-columns: subgrid;
-			grid-template-rows: subgrid;
-			justify-items: end;
+      display: flex;
+      gap: 0.5em;
+
+      margin: auto;
 		}
 
 		.FiringArc__span {
-			grid-column: 1 / -1;
+      margin: auto;
 		}
 	}
 </style>

--- a/packages/ui/src/components/Viewport/FiringArcs/FiringArc.vue
+++ b/packages/ui/src/components/Viewport/FiringArcs/FiringArc.vue
@@ -123,11 +123,11 @@
 
 		background: var(--color-primary-contrast);
 		border: 1px solid;
-    border-radius: 0.3em;
+		border-radius: 0.3em;
 
-    font-size:  calc((16px + 2vmin) / 2);
+		font-size:  calc((16px + 2vmin) / 2);
 
-    line-height: 100%;
+		line-height: 100%;
 
 		pointer-events: none;
 		user-select: none;
@@ -135,14 +135,14 @@
 		.FiringArc__label-row {
 			grid-column: 1 / -1;
 
-      display: flex;
-      gap: 0.5em;
+			display: flex;
+			gap: 0.5em;
 
-      margin: auto;
+			margin: auto;
 		}
 
 		.FiringArc__span {
-      margin: auto;
+			margin: auto;
 		}
 	}
 </style>


### PR DESCRIPTION
Some tweaks to firing arc labels for better usability and syle sharing through app.

P.S. To improve the user experience, I would suggest making these label opacity 0.7 or 0.5 by default, since users often don't know that they are in the application. 

![image](https://github.com/user-attachments/assets/f2286ea6-99c5-4dd5-9412-9f1759313e33)

