### PR TITLE
add variable connection settings ('ws'/'wss' and 'no port'/'port')

### DIFF
--- a/packages/ui/src/components/OverlayHud/SyncSettings.vue
+++ b/packages/ui/src/components/OverlayHud/SyncSettings.vue
@@ -9,6 +9,15 @@
 	>
 		<div class="Sync__settings">
 			<div class="Sync__settings__item">
+				<label>Use Encryption</label>
+				<input
+					type="checkbox"
+					id="encryption"
+					v-model="connectionDetails.useEncryption"
+					@keydown.enter="connect"
+				/>
+			</div>
+			<div class="Sync__settings__item">
 				<label>Server address:</label>
 				<TextInput
 					v-model="connectionDetails.serverAddress"
@@ -69,10 +78,15 @@
 
 	const visible = defineModel('visible', { type: Boolean, required: true });
 
-	const connectionDetails = ref(getConnectionDetails() ?? { code : '', serverAddress : '' });
+	const connectionDetails = ref(getConnectionDetails() ?? { code : '', serverAddress : '', useEncryption: false});
 
 	const connect = () => {
 		const newUrl = new URL(window.location.href);
+		if (connectionDetails.value.useEncryption) {
+			newUrl.searchParams.set('useEncryption', ''); // ?useEncryption
+		} else {
+			newUrl.searchParams.delete('useEncryption');
+		}
 		newUrl.searchParams.set('serverAddress', connectionDetails.value.serverAddress);
 		newUrl.searchParams.set('code', connectionDetails.value.code);
 		if (newUrl.search === location.search) {

--- a/packages/ui/src/lib/settings.ts
+++ b/packages/ui/src/lib/settings.ts
@@ -50,6 +50,7 @@ export const settings = ref({
 	sync: null as {
 		serverAddress: string,
 		code: string,
+		useEncryption: boolean,
 	} | null,
 });
 

--- a/packages/ui/src/mixins/server-connection.ts
+++ b/packages/ui/src/mixins/server-connection.ts
@@ -60,7 +60,7 @@ export const useServerConnection = () => {
 		if (useEncryption) connType = 'wss';
 
 		return address
-			? `${connType}://${address}:${connPort}/?code=${encodeURIComponent(connectionDetails?.code ?? '')}`
+			? `${connType}://${address}${connPort}/?code=${encodeURIComponent(connectionDetails?.code ?? '')}`
 			: null;
 	});
 


### PR DESCRIPTION
Added variabulity to server connection.

You can set server connection be with ssl Encryption, and directing to server name without specified PORT.

I'm hosting it through cloudflare, so SSL is mandatory. Web app side is needed Websocket connection to be WSS type. Server side needed to be without specified port (Port specified in DNS settings of cloudflare).

So i've added checkbox for using encrypted (SSL) connection
And slightly modified server adress code, so you now can get it without specifiing port.

Back compatibility saved with little caviat - now you need to specify connection port explicitly (SERVER_NAME:PORT)

![image](https://github.com/user-attachments/assets/c5baf6ae-a776-43ef-8a4b-7774c1d5ad5f)

Server side can be hosted as is and get SSL on top through Nginx Proxy or Cloudflare.